### PR TITLE
opam: depend on mirage-runtime >= 4.0.0, not mirage

### DIFF
--- a/mirage-xen.opam
+++ b/mirage-xen.opam
@@ -26,8 +26,8 @@ depends: [
   "mirage-runtime" {>= "3.7.0"}
   "logs"
   "fmt"
-  ("ocaml-freestanding" {>= "0.6.2"} & 
-  "solo5-bindings-xen" {>= "0.6.7"}) | "mirage" {>= "4.0.0"}
+  ("ocaml-freestanding" {>= "0.6.2"} &
+  "solo5-bindings-xen" {>= "0.6.7"}) | "mirage-runtime" {>= "4.0.0"}
   "bheap" {>= "2.0.0"}
   "duration"
 ]


### PR DESCRIPTION
done as well in https://github.com/mirage/mirage-dev/pull/367 -- see also https://github.com/ocaml/opam-repository/pull/19814